### PR TITLE
Handle panic button using the appropriate event

### DIFF
--- a/smartapps/arnbme/shm-delay.src/shm-delay.groovy
+++ b/smartapps/arnbme/shm-delay.src/shm-delay.groovy
@@ -378,7 +378,7 @@ def initialize()
 		subscribe (location, "mode", keypadModeHandler)
 		if (globalPanic)
 			{
-		    subscribe (globalKeypadDevices, "contact.open", keypadPanicHandler)
+		    subscribe (globalKeypadDevices, "button.pushed", keypadPanicHandler)
 		    }
 		globalKeypadDevices?.each
 			{


### PR DESCRIPTION
Contact is used for open/close sensors, use the DTH report for button pushing instead as it's more appropriate and for future compatibility